### PR TITLE
Configure VSCode Support for Linting Go Built via Bazel

### DIFF
--- a/.vscode/gopackagesdriver.sh
+++ b/.vscode/gopackagesdriver.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec bazelisk run -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+  "go.goroot": "${workspaceFolder}/bazel-${workspaceFolderBasename}/external/go_sdk",
+  "go.toolsEnvVars": {
+    "GOPACKAGESDRIVER": "${workspaceFolder}/.vscode/gopackagesdriver.sh"
+  },
+  "go.enableCodeLens": {
+    "runtest": false
+  },
+  "gopls": {
+    "build.directoryFilters": [
+      "-bazel-bin",
+      "-bazel-out",
+      "-bazel-testlogs",
+      "-bazel-${workspaceFolderBasename}"
+    ],
+    "formatting.gofumpt": true,
+    "formatting.local": "github.com/bar-raisers/${workspaceFolderBasename}",
+    "ui.completion.usePlaceholders": true,
+    "ui.semanticTokens": true,
+    "ui.codelenses": {
+      "gc_details": false,
+      "regenerate_cgo": false,
+      "generate": false,
+      "test": false,
+      "tidy": false,
+      "upgrade_dependency": false,
+      "vendor": false
+    }
+  },
+  "go.useLanguageServer": true
+}


### PR DESCRIPTION
VSCode extensions for linting Go are not compatible with projects built with Bazel out of the box. There are a couple issues related to this:

1. Bazel-built projects do not make use of the `go.mod` file to specify external dependencies like typical Go projects do.
2. VSCode has no knowledge of code generated at build time by Bazel such as Protobuf implementations when linting or autocompleting code.

Configure VSCode to utilize the Go toolchain provided by our Bazel project to resolve the above issues.