### PR TITLE
Add gRPC and Protobuf Dependencies

### DIFF
--- a/.bazel/base.bzl
+++ b/.bazel/base.bzl
@@ -5,6 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def workspace_base():
     download_gazelle_archives()
     download_go_archives()
+    download_proto_archives()
 
 def download_gazelle_archives():
     http_archive(
@@ -23,5 +24,15 @@ def download_go_archives():
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
             "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        ],
+    )
+
+def download_proto_archives():
+    http_archive(
+        name = "rules_proto",
+        sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+        strip_prefix = "rules_proto-5.3.0-21.7",
+        urls = [
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
         ],
     )

--- a/.bazel/go.bzl
+++ b/.bazel/go.bzl
@@ -1,7 +1,19 @@
 """Go Workspace Configuration for Repository"""
 
+load("@bazel_gazelle//:deps.bzl", "go_repository")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 def workspace_go():
     go_rules_dependencies()
     go_register_toolchains(version = "1.21.3")
+
+    load_dependencies()
+
+def load_dependencies():
+    go_repository(
+        name = "org_golang_google_grpc",
+        build_file_proto_mode = "disable",
+        importpath = "google.golang.org/grpc",
+        sum = "h1:f+PlOh7QV4iIJkPrx5NQ7qaNGFQ3OTse67yaDHfju4E=",
+        version = "v1.41.0",
+    )

--- a/.bazel/proto.bzl
+++ b/.bazel/proto.bzl
@@ -1,0 +1,7 @@
+"""Proto Workspace Configuration for Repository"""
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+def workspace_proto():
+    rules_proto_dependencies()
+    rules_proto_toolchains()


### PR DESCRIPTION
Add gRPC and Protobuf dependencies to Bazel toolchain.