### PR TITLE
Build Gazelle on Workspace Launch

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,16 @@
+# Documentation available at: https://www.gitpod.io/docs/configure/workspaces
+
 image:
   file: /.gitpod/Dockerfile
 
 tasks:
   - name: Build Gazelle
-    init: bazelisk build //:gazelle && exit
+    command: |
+      bazelisk build //:gazelle
+      exit
     openMode: tab-after
   - name: Install Trunk Linters
-    init: trunk install && exit
+    init: |
+      trunk install
+      exit
     openMode: tab-after


### PR DESCRIPTION
Building Gazelle during the workspace prebuild process does not persist post workspace launch, the build has to be done all over again. Modify the workspace configuration to build Gazelle post workspace launch.